### PR TITLE
Initiating an effort for customer responsibility model research.

### DIFF
--- a/research-2023/effort-responsibility-sharing/README.md
+++ b/research-2023/effort-responsibility-sharing/README.md
@@ -4,7 +4,7 @@
 
 ## Problem Statement
 
-OSCAL SSP authors need the ability to export content from a full SSP, suitable for customers to import into another SSP, without exposing all content of the full SSP. At a minimum, this exported content should include customer responsibility statements associated with components and control definition statements. When the SSP author uses optional syntax to define customer-consumable content about what is inherited, this content must also be included.
+OSCAL SSP authors need the ability to export particular content pertaining to controls that can be inherited by another system, without exposing all content of the full SSP or of those inheritable controls. This exported content must be suitable for customers to import into a new SSP of the system which inherits controls.
 
 - [Original Issue](https://github.com/usnistgov/OSCAL/issues/722)
 

--- a/research-2023/effort-responsibility-sharing/README.md
+++ b/research-2023/effort-responsibility-sharing/README.md
@@ -1,0 +1,25 @@
+# Define: An Approach to Communicating Responsibilities and Inheritance in OSCAL
+
+> Status: Initiation
+
+## Problem Statement
+
+OSCAL SSP authors need the ability to export content from a full SSP, suitable for customers to import into another SSP, without exposing all content of the full SSP. At a minimum, this exported content should include customer responsibility statements associated with components and control definition statements. When the SSP author uses optional syntax to define customer-consumable content about what is inherited, this content must also be included.
+
+- [Original Issue](https://github.com/usnistgov/OSCAL/issues/722)
+
+## Spirals
+
+- Not Started
+
+## Summary
+
+N/A
+
+## Presented
+
+N/A
+
+## Feedback
+
+N/A


### PR DESCRIPTION
Creating a paper trail that would be used in research to follow the development effort to create export examples.  This is for creation of a research effort.  Since this was already in progress as an effort prior to stand up of the DEFINE research pillar, we are initiating here.

- https://github.com/usnistgov/OSCAL-DEFINE/issues/5